### PR TITLE
use socklen_t instead of u32 for bind() parameter

### DIFF
--- a/src/phy/sys/raw_socket.rs
+++ b/src/phy/sys/raw_socket.rs
@@ -70,7 +70,7 @@ impl RawSocketDesc {
             let res = libc::bind(
                 self.lower,
                 &sockaddr as *const libc::sockaddr_ll as *const libc::sockaddr,
-                mem::size_of::<libc::sockaddr_ll>() as u32,
+                mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
             );
             if res == -1 {
                 return Err(io::Error::last_os_error());


### PR DESCRIPTION
cherry-pick from #593, necessary for [onionmasq#5](https://gitlab.torproject.org/tpo/core/onionmasq/-/issues/5)